### PR TITLE
Add react native documentation.

### DIFF
--- a/javascript/connect-webrtc.mdx
+++ b/javascript/connect-webrtc.mdx
@@ -10,6 +10,7 @@ description: "The useWebRTC hook simplify the process of connecting to Outspeedâ
 ```tsx WebRTCApp.tsx
 import React from "react";
 import { useWebRTC, RealtimeVideo } from "@outspeed/react";
+import { createConfig } from "@outspeed/core";
 
 export default function App() {
   const { 
@@ -18,12 +19,12 @@ export default function App() {
     getRemoteVideoTrack,
     getLocalVideoTrack
     } = useWebRTC({
-      config: {
+      config: createConfig({
         // Add your function URL.
         functionURL: "<my-function-url>", 
-        audio: true,
-        video: true,
-      },
+        audioConstraints: {},
+        videoConstraints: {}
+      }),
     });
 
   return (
@@ -45,12 +46,12 @@ export default function App() {
 The code shown establishes a peer connection with the backend and streams local audio and video to it.
 If the backend is configured to return the audio and video, they will be displayed as well.
 
-- We import necessary components from the `@outspeed/react` library.
+- We import necessary components from the `@outspeed/react` and `@outspeed/core` libraries.
 - `useWebRTC`: This hook is used to manage WebRTC connections. It provides methods like connect,
 getRemoteVideoTrack, and getLocalVideoTrack. Visit [here](./useWebRTC) to learn more about `useWebRTC`.
 - The `useWebRTC` hook is set up with a URL (`functionURL`) and options to enable audio and video. We can also use `useCreateConfig` to create a config, visit [here](./useCreateConfig).
-  - `audio: true`: This selects the default audio input device, and stream it to the backend.
-  - `video: true`: This selects the default video input device, and stream it to the backend.
+  - `audioConstraints: {}`: This selects the default audio input device and streams the audio to the backend. You can also specify any [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) to customize the audio input.
+  - `videoConstraints: {}`: This selects the default video input device and streams the video to the backend. Similar to audio, you can pass [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) to define specific video input settings.
 - Video Streams: Using `RealtimeVideo` component to view streams. Learn more about `RealtimeVideo` component [here](./RealtimeVideo).
 
 

--- a/javascript/introduction.mdx
+++ b/javascript/introduction.mdx
@@ -12,6 +12,7 @@ Currently, Outspeed JS SDK contains the following packages:
 
 - **@outspeed/core**: The core package provides the basic functionality for connecting to the `outspeed` backend and managing media streams.
 - **@outspeed/react**: This packages contains all the React components needed to integrate realtime communication into your React application.
+- **@outspeed/reacct-native**: This package contains all the React Native components and hooks needed to integrate Outspeed Application into you React Native application.
 
 ### Resources
 

--- a/javascript/react-native-RealtimePlayer.mdx
+++ b/javascript/react-native-RealtimePlayer.mdx
@@ -1,0 +1,66 @@
+---
+title: 'RealtimeVideo'
+description: 'A component for managing local or remote video track.'
+---
+
+<RequestExample>
+
+```jsx VideoContainer.jsx
+import { RealtimeVideo } from "@outspeed/react";
+
+
+export function VideoContainer() {
+  const { videoTrack } = props
+
+  return (
+    <div>
+      <RealtimeVideo track={videoTrack} />
+    </div>
+  );
+}
+```
+
+```tsx VideoContainer.tsx
+import { Track } from "@outspeed/core";
+import { RealtimeVideo } from "@outspeed/react";
+
+type TVideoContainerProps = {
+  videoTrack?: Track;
+}
+
+export function VideoContainer(props: TVideoContainerProps) {
+  const { videoTrack } = props
+
+  return (
+    <div>
+      <RealtimeVideo track={videoTrack} />
+    </div>
+  );
+}
+```
+</RequestExample>
+
+<Note>All of our components are built using Tailwind CSS. Make sure to set it up correctly by following the guide available [here](https://tailwindcss.com/docs/installation).</Note>
+
+
+`RealtimeVideo` can manage local or remote video tracks. It uses an HTML video element internally to
+play the video track. 
+
+## Props
+
+<ParamField body="track" type="Track">
+  A local or remote video track.
+</ParamField>
+
+### Resources
+
+<CardGroup cols={1}>
+  <Card
+    title="RealtimeVideo"
+    icon="github"
+    iconType="solid"
+    href="https://github.com/outspeed-ai/outspeed-js/blob/main/packages/react/src/components/realtime-video.tsx"
+  >
+    Explore the `<RealtimeVideo />` code on GitHub to learn how to create your own chat component.
+  </Card>
+</CardGroup>

--- a/javascript/react-native-RealtimePlayer.mdx
+++ b/javascript/react-native-RealtimePlayer.mdx
@@ -1,66 +1,41 @@
 ---
-title: 'RealtimeVideo'
+title: 'RealtimePlayer'
 description: 'A component for managing local or remote video track.'
 ---
 
 <RequestExample>
 
-```jsx VideoContainer.jsx
-import { RealtimeVideo } from "@outspeed/react";
+```jsx RealtimePlayerContainer.jsx
+import { RealtimePlayer } from "@outspeed/react";
 
 
-export function VideoContainer() {
-  const { videoTrack } = props
+export function RealtimePlayerContainer() {
+  const { remoteStream } = props
 
-  return (
-    <div>
-      <RealtimeVideo track={videoTrack} />
-    </div>
-  );
+  return <RealtimePlayer streamURL={remoteStream.toURL()} />
 }
 ```
 
-```tsx VideoContainer.tsx
-import { Track } from "@outspeed/core";
-import { RealtimeVideo } from "@outspeed/react";
+```tsx RealtimePlayerContainer.tsx
+import { RealtimePlayer } from '@outspeed/react-native/RealtimePlayer';
 
-type TVideoContainerProps = {
-  videoTrack?: Track;
+type TRealtimePlayerContainerProps = {
+  remoteStream: MediaStream;
 }
 
-export function VideoContainer(props: TVideoContainerProps) {
-  const { videoTrack } = props
+export function RealtimePlayerContainer(props: TRealtimePlayerContainerProps) {
+  const { remoteStream } = props
 
-  return (
-    <div>
-      <RealtimeVideo track={videoTrack} />
-    </div>
-  );
+  return <RealtimePlayer streamURL={stream.toURL()} />
 }
 ```
 </RequestExample>
 
-<Note>All of our components are built using Tailwind CSS. Make sure to set it up correctly by following the guide available [here](https://tailwindcss.com/docs/installation).</Note>
 
-
-`RealtimeVideo` can manage local or remote video tracks. It uses an HTML video element internally to
-play the video track. 
+`RealtimePlayer` is a React Native component built using react-native-webrtc's `RTCView` to display WebRTC video streams.
 
 ## Props
 
-<ParamField body="track" type="Track">
-  A local or remote video track.
+<ParamField body="streamURL" type="Track">
+  The URL of the WebRTC stream to be rendered.
 </ParamField>
-
-### Resources
-
-<CardGroup cols={1}>
-  <Card
-    title="RealtimeVideo"
-    icon="github"
-    iconType="solid"
-    href="https://github.com/outspeed-ai/outspeed-js/blob/main/packages/react/src/components/realtime-video.tsx"
-  >
-    Explore the `<RealtimeVideo />` code on GitHub to learn how to create your own chat component.
-  </Card>
-</CardGroup>

--- a/javascript/react-native-connect-webrtc.mdx
+++ b/javascript/react-native-connect-webrtc.mdx
@@ -11,15 +11,17 @@ description: "The useWebRTC hook simplify the process of connecting to Outspeedâ
 import React from "react";
 import { Text, SafeAreaView, Button } from "react-native";
 import { registerGlobals } from "react-native-webrtc";
+import InCallManager from "react-native-incall-manager";
 import { useWebRTC, RealtimePlayer } from "@outspeed/react-native";
 import { createConfig } from "@outspeed/core/dist/create-config";
 
 registerGlobals();
 
 export default function HomeScreen() {
-  const { connect, remoteTracks, connectionStatus } = useWebRTC();
+  const { connect, remoteStreams, connectionStatus } = useWebRTC();
 
   const createConfigAndConnect = React.useCallback(async () => {
+    InCallManager.setSpeakerphoneOn(true);
     const config = createConfig({
       // Add your function url
       functionURL: "<my-function-url>", 
@@ -35,8 +37,8 @@ export default function HomeScreen() {
     <SafeAreaView style={{ display: "flex", marginTop: 50 }}>
       <Text>Connection Status: {connectionStatus}</Text>
       <Button title="Connect" onPress={createConfigAndConnect} />
-      {remoteTracks[0] && (
-        <RealtimePlayer streamURL={remoteTracks[0].toURL()} />
+      {remoteStreams[0] && (
+        <RealtimePlayer streamURL={remoteStreams[0].toURL()} />
       )}
     </SafeAreaView>
   );

--- a/javascript/react-native-connect-webrtc.mdx
+++ b/javascript/react-native-connect-webrtc.mdx
@@ -1,0 +1,75 @@
+---
+title: "Connecting to a WebRTC backend"
+sidebarTitle: "WebRTC"
+description: "The useWebRTC hook simplify the process of connecting to Outspeed’s WebRTC backend."
+---
+
+<Note>We assume you have already deployed your backend. If not, please follow [this tutorial](/outspeed_sdk/cli/deploy) to deploy your backend with `outspeed-client`.</Note>
+
+<RequestExample>
+```tsx WebRTCReactNativeApp.tsx
+import React from "react";
+import { Text, SafeAreaView, Button } from "react-native";
+import { registerGlobals } from "react-native-webrtc";
+import { useWebRTC, RealtimePlayer } from "@outspeed/react-native";
+import { createConfig } from "@outspeed/core/dist/create-config";
+
+registerGlobals();
+
+export default function HomeScreen() {
+  const { connect, remoteTracks, connectionStatus } = useWebRTC();
+
+  const createConfigAndConnect = React.useCallback(async () => {
+    const config = createConfig({
+      // Add your function url
+      functionURL: "<my-function-url>", 
+      audioConstraints: {}
+    });
+
+    connect({
+      config,
+    });
+  }, [connect]);
+
+  return (
+    <SafeAreaView style={{ display: "flex", marginTop: 50 }}>
+      <Text>Connection Status: {connectionStatus}</Text>
+      <Button title="Connect" onPress={createConfigAndConnect} />
+      {remoteTracks[0] && (
+        <RealtimePlayer streamURL={remoteTracks[0].toURL()} />
+      )}
+    </SafeAreaView>
+  );
+}
+```
+</RequestExample>
+
+The code shown establishes a peer connection with the backend and streams local audio to it.
+
+- We import necessary components from the `@outspeed/react-native` and `@outspeed/core` libraries.
+- `useWebRTC`: This hook is used to manage WebRTC connections. Visit [here](./react-native-useWebRTC) to learn more about `useWebRTC`.
+- The `useWebRTC` hook is set up with a URL (`functionURL`) and option to enable audio.
+  - `audioConstraints: {}`: This selects the default audio input device and streams the audio to the backend. You can also specify any [MediaTrackConstraints](https://developer.mozilla.org/en-US/docs/Web/API/MediaTrackConstraints) to customize the audio input.
+- Streaming: Using `RealtimePlayer` component to stream. Learn more about `RealtimePlayer` component [here](./react-native-RealtimePlayer).
+
+
+### Resources
+
+<CardGroup cols={2}>
+   <Card
+    title="Example"
+    icon="github"
+    iconType="solid"
+    href="https://github.com/outspeed-ai/react-native-playground"
+  >
+    Explore our example repository where we use `@outspeed/react-native` to build a mobile app that connects to the Outspeed backend.
+  </Card>
+  <Card
+    title="GitHub"
+    icon="github"
+    iconType="solid"
+    href="https://github.com/outspeed-ai/outspeed-js/tree/main/packages/react-native"
+  >
+    Check out the GitHub repository of `@outspeed/react-native`.
+  </Card>
+</CardGroup>

--- a/javascript/react-native-create-config.mdx
+++ b/javascript/react-native-create-config.mdx
@@ -1,0 +1,78 @@
+---
+title: "createConfig"
+description: "A function to create config for `useWebRTC` hook."
+---
+
+
+<RequestExample>
+
+```tsx createConfig.ts
+import { createConfig } from "@outspeed/core/dist/create-config";
+
+const config = createConfig({
+  functionURL,
+  offerURL,
+  audioDeviceId,
+  videoDeviceId,
+  audioConstraints,
+  videoConstraints,
+  audioCodec,
+  videoCodec,
+  videoTransform,
+  dataChannelOptions,
+  logger,
+})
+```
+</RequestExample>
+
+`createConfig` provides useful default settings for options you may not configure yourself.
+As we continuously update the internal logic and configuration options, using this function
+will generally ensure that you stay up-to-date with the latest features without needing to
+make any manual updates.
+
+<ParamField body="functionURL" type="string | undefined">
+- The URL of the function to be used in the configuration.
+- Either `functionURL` or `offerURL` is required. Otherwise, `createConfig` will throw an error.
+</ParamField>
+
+<ParamField body="offerURL" type="string | undefined">
+- Optional URL for local testing. If both `functionURL` and `offerURL` are provided, `functionURL` takes precedence.
+- Either `functionURL` or `offerURL` is required. Otherwise, `createConfig` will throw an error.
+</ParamField>
+
+<ParamField body="audioDeviceId" type="string | undefined">
+- Optional device ID for the selected audio input device.
+</ParamField>
+
+<ParamField body="videoDeviceId" type="string | undefined">
+- Optional device ID for the selected video input device.
+</ParamField>
+
+<ParamField body="audioConstraints" type="MediaTrackConstraints | undefined">
+- Optional media track constraints for capturing audio.
+</ParamField>
+
+<ParamField body="videoConstraints" type="MediaTrackConstraints | undefined">
+- Optional media track constraints for capturing video.
+</ParamField>
+
+<ParamField body="audioCodec" type="TAudioCodec | undefined">
+- Optional codec for audio, defaults to `"PCMU/8000"` if not provided.
+</ParamField>
+
+<ParamField body="videoCodec" type="TVideoCodec | undefined">
+- Optional codec for video.
+</ParamField>
+
+<ParamField body="videoTransform" type="TVideoTransform | undefined">
+- Optional transformation type for video processing.
+</ParamField>
+
+<ParamField body="dataChannelOptions" type="RTCDataChannelInit | undefined">
+- Optional configuration options for the RTC data channel.
+</ParamField>
+
+<ParamField body="logger" type="Logger | undefined">
+- Optional logger for logging and debugging purposes.
+- This must implement the [Logger](https://github.com/outspeed-ai/outspeed-js/blob/main/packages/core/src/Logger/Logger.ts) class.
+</ParamField>

--- a/javascript/react-native-installation.mdx
+++ b/javascript/react-native-installation.mdx
@@ -9,22 +9,17 @@ We assume you already have a React Native project set up. If you don't, please f
 <CodeGroup>
 
 ```bash npm
-npm install @outspeed/core @outspeed/react-native react-native-webrtc
+npm install @outspeed/core @outspeed/react-native react-native-webrtc react-native-incall-manager
 ```
 
 ```bash yarn
-yarn add @outspeed/core @outspeed/react-native react-native-webrtc
+yarn add @outspeed/core @outspeed/react-native react-native-webrtc react-native-incall-manager
 ```
 
 ```bash pnpm
-pnpm install @outspeed/core @outspeed/react-native react-native-webrtc 
+pnpm install @outspeed/core @outspeed/react-native react-native-webrtc react-native-incall-manager
 ```
 </CodeGroup>
-
-`@outspeed/core` and `@outspeed/react-native` are open source, and the code is available on [GitHub]((https://github.com/outspeed-ai/outspeed-js)).
-
-If you come across any bugs or have a feature request, feel free to open an issue. If you're interested in contributing,
-you can submit a pull request. We're actively maintaining the repository and appreciate contributions!
 
 
 ### Specific to Expo Apps
@@ -40,15 +35,15 @@ Run the following command to install `config-plugins/react-native-webrtc`
 <CodeGroup>
 
 ```bash npm
-npm install config-plugins/react-native-webrtc
+npm install @config-plugins/react-native-webrtc
 ```
 
 ```bash yarn
-yarn add config-plugins/react-native-webrtc
+yarn add @config-plugins/react-native-webrtc
 ```
 
 ```bash pnpm
-pnpm install config-plugins/react-native-webrtc 
+pnpm install @config-plugins/react-native-webrtc 
 ```
 </CodeGroup>
 
@@ -63,6 +58,9 @@ configuration file. This ensures that Expo includes the plugin during the prebui
   }
 }
 ```
+
+If you come across any bugs or have a feature request, feel free to open an issue. If you're interested in contributing,
+you can submit a pull request. We're actively maintaining the repository and appreciate contributions!
 
 
 ### Resources

--- a/javascript/react-native-installation.mdx
+++ b/javascript/react-native-installation.mdx
@@ -1,0 +1,88 @@
+---
+title: "Installation"
+sidebarTitle: "Installation"
+description: ""
+---
+
+We assume you already have a React Native project set up. If you don't, please follow the [official guide](https://reactnative.dev/docs/environment-setup) to create one.
+
+<CodeGroup>
+
+```bash npm
+npm install @outspeed/core @outspeed/react-native react-native-webrtc
+```
+
+```bash yarn
+yarn add @outspeed/core @outspeed/react-native react-native-webrtc
+```
+
+```bash pnpm
+pnpm install @outspeed/core @outspeed/react-native react-native-webrtc 
+```
+</CodeGroup>
+
+`@outspeed/core` and `@outspeed/react-native` are open source, and the code is available on [GitHub]((https://github.com/outspeed-ai/outspeed-js)).
+
+If you come across any bugs or have a feature request, feel free to open an issue. If you're interested in contributing,
+you can submit a pull request. We're actively maintaining the repository and appreciate contributions!
+
+
+### Specific to Expo Apps
+
+Since we are using `react-native-webrtc` internally, which includes native code, it is not available in the Expo Go app by default.
+However, you can make it work by using the `expo-dev-client` library along with the out-of-tree 
+`@config-plugins/react-native-webrtc` package.
+
+To install expo-dev-client follow the instructions avaialbe here: https://docs.expo.dev/develop/development-builds/create-a-build/
+
+Run the following command to install `config-plugins/react-native-webrtc`
+
+<CodeGroup>
+
+```bash npm
+npm install config-plugins/react-native-webrtc
+```
+
+```bash yarn
+yarn add config-plugins/react-native-webrtc
+```
+
+```bash pnpm
+pnpm install config-plugins/react-native-webrtc 
+```
+</CodeGroup>
+
+After installation, add the [config plugin]((https://docs.expo.dev/config-plugins/introduction/#use-a-config-plugin)) to the plugins array in the Expo
+configuration file. This ensures that Expo includes the plugin during the prebuild process.
+
+```json app.json
+{
+  "expo": {
+    "plugins": ["@config-plugins/react-native-webrtc"]
+		// ...
+  }
+}
+```
+
+
+### Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="Example"
+    icon="github"
+    iconType="solid"
+    href="https://github.com/outspeed-ai/react-native-playground"
+  >
+    Explore our example repository where we use `@outspeed/react-native` to build a mobile app that connects to the Outspeed backend.
+  </Card>
+
+  <Card
+    title="Setup Expo"
+    icon="globe"
+    iconType="solid"
+    href="https://docs.expo.dev/get-started/set-up-your-environment/"
+  >
+    Learn how to set up your development environment to start building with Expo.
+  </Card>
+</CardGroup>

--- a/javascript/react-native-usage.mdx
+++ b/javascript/react-native-usage.mdx
@@ -1,0 +1,39 @@
+---
+title: "Usage"
+sidebarTitle: "Usage"
+description: ""
+---
+
+`@outspeed/react-native` simplifies connecting your React Native app to a backend
+deployed with `outspeed-client`. It provides all the necessary components and
+hooks to easily establish the connection between your application and the backend.
+
+This guide assumes that you've already deployed your backend using `outspeed-client`,
+have a `function URL` ready, and have an existing React Native app set up. If not, please
+follow [this tutorial](/outspeed_sdk/cli/deploy) to deploy your backend with
+`outspeed-client` and [this tutorial](https://docs.expo.dev/tutorial/create-your-first-app/) to
+set up a new React Native app.
+
+By the end of this guide, you'll learn how to connect your React frontend to
+the backend deployed using `outspeed-client`.
+
+### Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="@outspeed/react-native"
+    icon="npm"
+    iconType="solid"
+    href="https://www.npmjs.com/package/@outspeed/react-native"
+  >
+    Explore `@outspeed/react-native` on NPM.
+  </Card>
+  <Card
+    title="GitHub"
+    icon="github"
+    iconType="solid"
+    href="https://github.com/outspeed-ai/outspeed-js/tree/main/packages/react-native"
+  >
+    Check out the GitHub repository of `@outspeed/react-native`.
+  </Card>
+</CardGroup>

--- a/javascript/react-native-useWebRTC.mdx
+++ b/javascript/react-native-useWebRTC.mdx
@@ -1,0 +1,126 @@
+---
+title: "useWebRTC"
+sidebarTitle: "useWebRTC"
+description: "A hook to manage outspeed's WebRTC connection."
+---
+
+<RequestExample>
+```ts useWebRTC.ts
+import { useWebRTC } from "@outspeed/react"
+
+const {
+  connectionStatus,
+  connect,
+  disconnect,
+  reset,
+  dataChannel,
+  addEventListener,
+  removeEventListener,
+  getLocalAudioTrack,
+  getLocalVideoTrack,
+  getLocalTracks,
+  getRemoteAudioTrack,
+  getRemoteVideoTrack,
+} = useWebRTC({
+  config
+});
+
+```
+</RequestExample>
+
+The `useWebRTC` hook handles all the necessary logic to manage a WebRTC connection with the Outspeed's backend.
+
+### Options
+
+<ParamField body="config" type="TRealtimeConfig">
+- **Required**
+- This configuration is used by the `useWebRTC` hook to initialize local audio and video streams, set up peer connections, enable logging, and more.
+- Learn more about `config` [here](./useCreateConfig).
+</ParamField>
+
+### Returns
+
+<ParamField body="connectionStatus" type="TWebRTCConnectionStatus">
+- `Init` when the component mounts and `config` is undefined.
+- `SetupCompleted` when `config` is defined but `connect` hasn't been called.
+- `Connecting` when `connect` is called and the connection to the backend is in progress.
+- `Connected` when the connection to the backend is successful.
+- `Failed` if the connection to the backend fails.
+- `Disconnecting` when attempting to disconnect from the backend.
+- `Disconnected` when successfully disconnected from the backend.
+</ParamField>
+
+<ParamField body="connect" type="() => void">
+- A function that initiates the connection to the backend.
+- Be sure to call this when `connectionStatus` is `SetupCompleted`, otherwise it will have no effect.
+</ParamField>
+
+<ParamField body="disconnect" type="() => void">
+- A function to disconnect from the backend.
+- Be sure to call this when `connectionStatus` is `Connected`, otherwise it will have no effect.
+</ParamField>
+
+<ParamField body="reset" type="() => void">
+- A function to reset the connection.
+- Be sure to call this when `connectionStatus` is `Disconnected`, otherwise it will have no effect.
+- This will set the `connectionStatus` to `Init`.
+</ParamField>
+
+<ParamField body="dataChannel" type="WebRTCDataChannel">
+- A WebRTC data channel for sending and receiving messages.
+- To send a message to the backend, use `dataChannel.send({ type: "message", data: "Hello" })`.
+- To listen for messages from the backend, use `dataChannel.addEventListener('message', (message) => console.log(message))`.
+- To remove a message listener, use `dataChannel.removeEventListener('message', onMessage)`.
+- The available events are `open` (triggered when the data channel opens), `close` (triggered when the data channel closes), and `message` (triggered when a message is received).
+</ParamField>
+
+<ParamField body="addEventListener" type="(type: TRealtimeConnectionListenerType, listener: TRealtimeConnectionListener) => TUseWebRTCReturn">
+- To attach an event listener to the RTCPeerConnection.
+- Refer to this [MDN doc](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#events) to learn more.
+</ParamField>
+
+<ParamField body="removeEventListener" type="(type: TRealtimeConnectionListenerType, listener: TRealtimeConnectionListener) => TUseWebRTCReturn">
+- To remove an event listener from the RTCPeerConnection.
+</ParamField>
+
+<ParamField body="getLocalAudioTrack" type="() => Track | null">
+- Returns the first local audio track, or `null` if no audio track is available.
+- This is a reactive function that may trigger a re-render when a track is added or removed.
+</ParamField>
+
+<ParamField body="getLocalVideoTrack" type="() => Track | null">
+- Returns the first local video track, or `null` if no video track is available.
+- This is a reactive function that may trigger a re-render when a track is added or removed.
+</ParamField>
+
+<ParamField body="getRemoteAudioTrack" type="(remoteId: string) => Track | null | undefined">
+- Returns the first active remote audio track, or `null` if it doesn't exist. If the connection is still in progress, it may return `undefined`. Once the connection is updated, it will return the track.
+- This is a reactive function that may trigger a re-render when a track is added or removed.
+</ParamField>
+
+<ParamField body="getRemoteVideoTrack" type="(remoteId: string) => Track | null | undefined">
+- Returns the first active remote video track, or `null` if it doesn't exist. If the connection is still in progress, it may return `undefined`. Once the connection is updated, it will return the track.
+- This is a reactive function that may trigger a re-render when a track is added or removed.
+</ParamField>
+
+
+### Resources
+
+<CardGroup cols={2}>
+  <Card
+    title="WebRTC Realtime App"
+    icon="github"
+    iconType="solid"
+    href="https://github.com/outspeed-ai/outspeed-js/blob/main/examples/playground-js/src/webrtc/RealtimeApp.tsx"
+  >
+    Check out WebRTC Realtime App on GitHub
+  </Card>
+  <Card
+    title="useWebRTC"
+    icon="github"
+    iconType="solid"
+    href="https://github.com/outspeed-ai/outspeed-js/blob/main/packages/react/src/hooks/useWebRTC.ts"
+  >
+    Check out our useWebRTC code on Github.
+  </Card>
+</CardGroup>

--- a/javascript/react-native-useWebRTC.mdx
+++ b/javascript/react-native-useWebRTC.mdx
@@ -6,21 +6,17 @@ description: "A hook to manage outspeed's WebRTC connection."
 
 <RequestExample>
 ```ts useWebRTC.ts
-import { useWebRTC } from "@outspeed/react"
+import { useWebRTC } from "@outspeed/react-native"
 
 const {
-  connectionStatus,
   connect,
   disconnect,
-  reset,
+  connection,
+  connectionStatus,
   dataChannel,
-  addEventListener,
-  removeEventListener,
-  getLocalAudioTrack,
-  getLocalVideoTrack,
-  getLocalTracks,
-  getRemoteAudioTrack,
-  getRemoteVideoTrack,
+  remoteStreams,
+  getLocalAudioStream,
+  getLocalVideoStream,
 } = useWebRTC({
   config
 });
@@ -35,35 +31,25 @@ The `useWebRTC` hook handles all the necessary logic to manage a WebRTC connecti
 <ParamField body="config" type="TRealtimeConfig">
 - **Required**
 - This configuration is used by the `useWebRTC` hook to initialize local audio and video streams, set up peer connections, enable logging, and more.
-- Learn more about `config` [here](./useCreateConfig).
+- Learn more about `config` [here](./react-native-create-config).
 </ParamField>
 
 ### Returns
 
 <ParamField body="connectionStatus" type="TWebRTCConnectionStatus">
 - `Init` when the component mounts and `config` is undefined.
-- `SetupCompleted` when `config` is defined but `connect` hasn't been called.
 - `Connecting` when `connect` is called and the connection to the backend is in progress.
 - `Connected` when the connection to the backend is successful.
 - `Failed` if the connection to the backend fails.
-- `Disconnecting` when attempting to disconnect from the backend.
 - `Disconnected` when successfully disconnected from the backend.
 </ParamField>
 
 <ParamField body="connect" type="() => void">
 - A function that initiates the connection to the backend.
-- Be sure to call this when `connectionStatus` is `SetupCompleted`, otherwise it will have no effect.
 </ParamField>
 
 <ParamField body="disconnect" type="() => void">
 - A function to disconnect from the backend.
-- Be sure to call this when `connectionStatus` is `Connected`, otherwise it will have no effect.
-</ParamField>
-
-<ParamField body="reset" type="() => void">
-- A function to reset the connection.
-- Be sure to call this when `connectionStatus` is `Disconnected`, otherwise it will have no effect.
-- This will set the `connectionStatus` to `Init`.
 </ParamField>
 
 <ParamField body="dataChannel" type="WebRTCDataChannel">
@@ -71,36 +57,21 @@ The `useWebRTC` hook handles all the necessary logic to manage a WebRTC connecti
 - To send a message to the backend, use `dataChannel.send({ type: "message", data: "Hello" })`.
 - To listen for messages from the backend, use `dataChannel.addEventListener('message', (message) => console.log(message))`.
 - To remove a message listener, use `dataChannel.removeEventListener('message', onMessage)`.
-- The available events are `open` (triggered when the data channel opens), `close` (triggered when the data channel closes), and `message` (triggered when a message is received).
 </ParamField>
 
-<ParamField body="addEventListener" type="(type: TRealtimeConnectionListenerType, listener: TRealtimeConnectionListener) => TUseWebRTCReturn">
-- To attach an event listener to the RTCPeerConnection.
-- Refer to this [MDN doc](https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection#events) to learn more.
-</ParamField>
 
-<ParamField body="removeEventListener" type="(type: TRealtimeConnectionListenerType, listener: TRealtimeConnectionListener) => TUseWebRTCReturn">
-- To remove an event listener from the RTCPeerConnection.
-</ParamField>
-
-<ParamField body="getLocalAudioTrack" type="() => Track | null">
-- Returns the first local audio track, or `null` if no audio track is available.
+<ParamField body="getLocalAudioStream" type="() => MediaStream | null">
+- Returns the first local audio stream, or `null` if no audio track is available.
 - This is a reactive function that may trigger a re-render when a track is added or removed.
 </ParamField>
 
-<ParamField body="getLocalVideoTrack" type="() => Track | null">
-- Returns the first local video track, or `null` if no video track is available.
+<ParamField body="getLocalVideoStream" type="() => MediaStream | null">
+- Returns the first local video stream, or `null` if no video track is available.
 - This is a reactive function that may trigger a re-render when a track is added or removed.
 </ParamField>
 
-<ParamField body="getRemoteAudioTrack" type="(remoteId: string) => Track | null | undefined">
-- Returns the first active remote audio track, or `null` if it doesn't exist. If the connection is still in progress, it may return `undefined`. Once the connection is updated, it will return the track.
-- This is a reactive function that may trigger a re-render when a track is added or removed.
-</ParamField>
-
-<ParamField body="getRemoteVideoTrack" type="(remoteId: string) => Track | null | undefined">
-- Returns the first active remote video track, or `null` if it doesn't exist. If the connection is still in progress, it may return `undefined`. Once the connection is updated, it will return the track.
-- This is a reactive function that may trigger a re-render when a track is added or removed.
+<ParamField body="remoteStreams" type="MediaStream[]">
+- An array of remote media stream.
 </ParamField>
 
 

--- a/mint.json
+++ b/mint.json
@@ -40,6 +40,10 @@
     {
       "name": "Outspeed JS SDK",
       "url": "javascript"
+    },
+    {
+      "name": "Outspeed React  SDK",
+      "url": "javascript"
     }
   ],
   "anchors": [
@@ -57,7 +61,9 @@
   "navigation": [
     {
       "group": "Get Started",
-      "pages": ["examples/quickstart"]
+      "pages": [
+        "examples/quickstart"
+      ]
     },
     {
       "group": "Conversational Bots",
@@ -99,11 +105,15 @@
     },
     {
       "group": "General",
-      "pages": ["outspeed_sdk/installation"]
+      "pages": [
+        "outspeed_sdk/installation"
+      ]
     },
     {
       "group": "CLI",
-      "pages": ["outspeed_sdk/cli/deploy"]
+      "pages": [
+        "outspeed_sdk/cli/deploy"
+      ]
     },
     {
       "group": "Python API",
@@ -123,29 +133,47 @@
     },
     {
       "group": "Getting Started",
-      "pages": ["javascript/introduction", "javascript/installation"]
-    },
-    {
-      "group": "Usage",
       "pages": [
-        "javascript/usage",
-        "javascript/connect-webrtc",
-        "javascript/connect-websocket"
+        "javascript/introduction"
       ]
     },
     {
-      "group": "API",
+      "group": "@outspeed/react",
       "pages": [
-        "javascript/createConfig",
-        "javascript/useWebRTC",
-        "javascript/useWebSocket",
-        "javascript/useAvailableMediaDevices",
-        "javascript/useCreateConfig",
-        "javascript/Form",
-        "javascript/RealtimeAudio",
-        "javascript/RealtimeAudioVisualizer",
-        "javascript/RealtimeVideo",
-        "javascript/RealtimeChat"
+        "javascript/installation",
+        "javascript/usage",
+        "javascript/connect-webrtc",
+        "javascript/connect-websocket",
+        {
+          "group": "API",
+          "pages": [
+            "javascript/createConfig",
+            "javascript/useWebRTC",
+            "javascript/useWebSocket",
+            "javascript/useAvailableMediaDevices",
+            "javascript/useCreateConfig",
+            "javascript/Form",
+            "javascript/RealtimeAudio",
+            "javascript/RealtimeAudioVisualizer",
+            "javascript/RealtimeVideo",
+            "javascript/RealtimeChat"
+          ]
+        }
+      ]
+    },
+    {
+      "group": "@outspeed/react-native",
+      "pages": [
+        "javascript/react-native-installation",
+        "javascript/react-native-usage",
+        "javascript/react-native-connect-webrtc",
+        {
+          "group": "API",
+          "pages": [
+            "javascript/react-native-useWebRTC",
+            "javascript/react-native-RealtimePlayer"
+          ]
+        }
       ]
     }
   ],

--- a/mint.json
+++ b/mint.json
@@ -140,8 +140,8 @@
     {
       "group": "@outspeed/react",
       "pages": [
-        "javascript/installation",
         "javascript/usage",
+        "javascript/installation",
         "javascript/connect-webrtc",
         "javascript/connect-websocket",
         {
@@ -164,13 +164,14 @@
     {
       "group": "@outspeed/react-native",
       "pages": [
-        "javascript/react-native-installation",
         "javascript/react-native-usage",
+        "javascript/react-native-installation",
         "javascript/react-native-connect-webrtc",
         {
           "group": "API",
           "pages": [
             "javascript/react-native-useWebRTC",
+            "javascript/react-native-create-config",
             "javascript/react-native-RealtimePlayer"
           ]
         }


### PR DESCRIPTION
# Summary

This PR adds documentation for the `@outspeed/react-native` SDK. It includes details on how users can install and use the SDK in their React Native (or Expo) projects to establish connections with the Outspeed backend using WebRTC.

# Key Updates

1. Introduction to `@outspeed/react-native`:
   - Overview.
   - Installation.
   - Example and explanation of how to use the `useWebRTC` hook to connect to the Outspeed backend.
   - Links to the repository and the plalyground.
2. Update the grouping of the different sections in the documentation for the Outspeed JS SDK. The sidebar now includes a section for a general introduction to all our SDKs, as well as separate sections for `@outspeed/react` and `@outspeed/react-native`.
3. Update `@outspeed/react` connect webrtc  docs little bit.


